### PR TITLE
Bug/clubs should not be able to use more than their points allowed

### DIFF
--- a/server.py
+++ b/server.py
@@ -4,14 +4,18 @@ from flask import Flask,render_template,request,redirect,flash,url_for
 
 def loadClubs():
     with open('clubs.json') as c:
-         listOfClubs = json.load(c)['clubs']
-         return listOfClubs
+        listOfClubs = json.load(c)['clubs']
+        for club in listOfClubs:
+            club['points'] = int(club['points'])
+        return listOfClubs
 
 
 def loadCompetitions():
     with open('competitions.json') as comps:
-         listOfCompetitions = json.load(comps)['competitions']
-         return listOfCompetitions
+        listOfCompetitions = json.load(comps)['competitions']
+        for comp in listOfCompetitions:
+            comp['numberOfPlaces'] = int(comp['numberOfPlaces'])
+        return listOfCompetitions
 
 
 app = Flask(__name__)
@@ -34,15 +38,20 @@ def showSummary():
     return render_template('welcome.html',club=club,competitions=competitions)
 
 
+@app.route('/book', defaults={'competition': '', 'club': ''}, strict_slashes=False)
+@app.route('/book/<competition>', defaults={'club': ''}, strict_slashes=False)
 @app.route('/book/<competition>/<club>')
 def book(competition,club):
-    foundClub = [c for c in clubs if c['name'] == club][0]
-    foundCompetition = [c for c in competitions if c['name'] == competition][0]
+    foundClub = next((c for c in clubs if c['name'] == club), None)
+    foundCompetition = next((c for c in competitions if c['name'] == competition), None)
     if foundClub and foundCompetition:
         return render_template('booking.html',club=foundClub,competition=foundCompetition)
-    else:
+    elif foundClub:
         flash("Something went wrong-please try again")
-        return render_template('welcome.html', club=club, competitions=competitions)
+        return render_template('welcome.html', club=foundClub, competitions=competitions), 404
+    else:
+        flash("Lost connection, please login")
+        return redirect(url_for('index'))
 
 
 @app.route('/purchasePlaces',methods=['POST'])
@@ -53,6 +62,38 @@ def purchasePlaces():
     competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
     flash('Great-booking complete!')
     return render_template('welcome.html', club=club, competitions=competitions)
+    competition = next((c for c in competitions if c['name'] == request.form.get('competition', None)), None)
+    club = next((c for c in clubs if c['name'] == request.form.get('club', None)), None)
+
+    if club and competition:
+        try:
+            placesRequired = int(request.form.get('places', 0))
+        except ValueError:
+            placesRequired = 0
+        if placesRequired <= 0:
+            flash('You must enter a valid number of places')
+            return render_template('booking.html', club=club, competition=competition), 403
+
+        purchase_power = int(club.get('points', 0))
+        if purchase_power < placesRequired:
+            flash(f"You don't have enough points to proceed with your request. Requested : {placesRequired}, still allowed : {purchase_power}")
+            return render_template('booking.html', club=club, competition=competition), 403
+
+        competition_available = int(competition.get('numberOfPlaces', 0))
+        if competition_available < placesRequired:
+            flash(f"Not enough available places for this competition. Requested : {placesRequired}, still available : {competition_available}")
+            return render_template('booking.html', club=club, competition=competition), 403
+
+        competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
+
+        flash('Great-booking complete!')
+        return render_template('welcome.html', club=club, competitions=competitions)
+    elif club:
+        flash("Something went wrong-please try again")
+        return render_template('welcome.html', club=club, competitions=competitions), 404
+    else:
+        flash("Lost connection, please login")
+        return redirect(url_for('index'))
 
 
 # TODO: Add route for points display

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -13,5 +13,6 @@
         <label for="places">How many places?</label><input type="number" name="places" id=""/>
         <button type="submit">Book</button>
     </form>
+    {% include 'messages.html' %}
 </body>
 </html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,9 @@ def client():
 @pytest.fixture
 def mock_clubs(mocker):
     clubs = [
-        {"name": "Club 001", "email": "001_club@gudlift.com", "points": "13"},
-        {"name": "Club 002", "email": "002_club@gudlift.com", "points": "4"},
-        {"name": "Club 003", "email": "003_club@gudlift.com", "points": "30"},
+        {"name": "Club 001", "email": "001_club@gudlift.com", "points": 13},
+        {"name": "Club 002", "email": "002_club@gudlift.com", "points": 4},
+        {"name": "Club 003", "email": "003_club@gudlift.com", "points": 30},
     ]
     mocker.patch.object(server, 'clubs', clubs)
     return clubs
@@ -26,9 +26,9 @@ def mock_clubs(mocker):
 def mock_competitions(mocker):
     competitions = [
         {"name": "Competition 001", "date": "2020-03-27 10:00:00",
-         "numberOfPlaces": "25"},
+         "numberOfPlaces": 25},
         {"name": "Competition 002", "date": "2020-10-22 13:30:00",
-         "numberOfPlaces": "13"}
+         "numberOfPlaces": 4}
     ]
     mocker.patch.object(server, 'competitions', competitions)
     return competitions

--- a/tests/integration/test_login.py
+++ b/tests/integration/test_login.py
@@ -6,9 +6,9 @@ def test_login_flow_success(client, mock_clubs, mock_competitions):
                                  data={"email": "001_club@gudlift.com"})
     assert response_login.status_code == 200
 
-    html = response_login.data.decode("utf-8")
-    assert 'Welcome, 001_club@gudlift.com' in html
-    assert 'Competition 001' in html
+    html_response = response_login.data.decode("utf-8")
+    assert 'Welcome, 001_club@gudlift.com' in html_response
+    assert 'Competition 001' in html_response
 
 
 def test_login_flow_failure(client, mock_clubs, mock_competitions):
@@ -19,8 +19,8 @@ def test_login_flow_failure(client, mock_clubs, mock_competitions):
                                  data={"email": "unknown@gudlift.com"})
     assert response_login.status_code == 401
 
-    html = response_login.data.decode("utf-8")
-    assert 'Welcome to the GUDLFT Registration Portal!' in html
+    html_response = response_login.data.decode("utf-8")
+    assert 'Welcome to the GUDLFT Registration Portal!' in html_response
 
 
 def test_logout_flow_success(client, mock_clubs, mock_competitions):

--- a/tests/integration/test_purchase_places.py
+++ b/tests/integration/test_purchase_places.py
@@ -1,0 +1,100 @@
+from html import unescape
+
+
+def test_purchase_places_flow_success(client, mock_clubs, mock_competitions):
+    response_login = client.post("/showSummary",
+                                 data={"email": "001_club@gudlift.com"})
+    html_response_login = response_login.data.decode("utf-8")
+    assert response_login.status_code == 200
+    assert 'Welcome, 001_club@gudlift.com' in html_response_login
+    assert 'Competition 001' in html_response_login
+    assert mock_competitions[0]['numberOfPlaces'] == 25
+    assert 'Number of Places: 25' in html_response_login
+
+    book_url = "/book/Competition 001/Club 001"
+    response_book = client.get(book_url)
+    html_response_book = response_book.data.decode("utf-8")
+
+    assert response_book.status_code == 200
+    assert (f"Booking for {mock_competitions[0]['name']} || GUDLFT"
+            in html_response_book)
+
+    request_args = {'club': 'Club 001', 'competition': 'Competition 001',
+                    'places': '5'}
+    response_purchase_places = client.post('/purchasePlaces',
+                                           data=request_args)
+    html_response_purchase_places = (
+        response_purchase_places.data.decode("utf-8"))
+
+    assert response_purchase_places.status_code == 200
+    assert mock_competitions[0]['numberOfPlaces'] == 20
+    assert 'Great-booking complete!' in html_response_purchase_places
+    assert 'Number of Places: 20' in html_response_purchase_places
+
+
+def test_purchase_places_more_than_club_points(
+        client, mock_clubs, mock_competitions):
+    response_login = client.post("/showSummary",
+                                 data={"email": "002_club@gudlift.com"})
+    html_response_login = response_login.data.decode("utf-8")
+    assert response_login.status_code == 200
+    assert 'Welcome, 002_club@gudlift.com' in html_response_login
+    assert 'Competition 001' in html_response_login
+    assert mock_competitions[0]['numberOfPlaces'] == 25
+    assert 'Number of Places: 25' in html_response_login
+
+    book_url = "/book/Competition 001/Club 002"
+    response_book = client.get(book_url)
+    html_response_book = response_book.data.decode("utf-8")
+
+    assert response_book.status_code == 200
+    assert (f"Booking for {mock_competitions[0]['name']} || GUDLFT"
+            in html_response_book)
+
+    request_args = {'club': 'Club 002', 'competition': 'Competition 001',
+                    'places': '5'}
+    response_purchase_places = client.post('/purchasePlaces',
+                                           data=request_args)
+    html_response_purchase_places = unescape(
+        response_purchase_places.data.decode("utf-8"))
+
+    assert response_purchase_places.status_code == 403
+    assert mock_competitions[0]['numberOfPlaces'] == 25
+    assert (("You don't have enough points to proceed with your request. "
+            "Requested : 5, still allowed : 4")
+            in html_response_purchase_places)
+    assert 'Places available: 25' in html_response_purchase_places
+
+
+def test_purchase_places_more_than_competition_places(
+        client, mock_clubs, mock_competitions):
+    response_login = client.post("/showSummary",
+                                 data={"email": "001_club@gudlift.com"})
+    html_response_login = response_login.data.decode("utf-8")
+    assert response_login.status_code == 200
+    assert 'Welcome, 001_club@gudlift.com' in html_response_login
+    assert 'Competition 002' in html_response_login
+    assert mock_competitions[1]['numberOfPlaces'] == 4
+    assert 'Number of Places: 4' in html_response_login
+
+    book_url = "/book/Competition 002/Club 001"
+    response_book = client.get(book_url)
+    html_response_book = response_book.data.decode("utf-8")
+
+    assert response_book.status_code == 200
+    assert (f"Booking for {mock_competitions[1]['name']} || GUDLFT" in
+            html_response_book)
+
+    request_args = {'club': 'Club 001', 'competition': 'Competition 002',
+                    'places': '5'}
+    response_purchase_places = client.post(
+        '/purchasePlaces', data=request_args)
+    html_response_purchase_places = unescape(
+        response_purchase_places.data.decode("utf-8"))
+
+    assert response_purchase_places.status_code == 403
+    assert mock_competitions[1]['numberOfPlaces'] == 4
+    assert (('Not enough available places for this competition. '
+            'Requested : 5, still available : 4')
+            in html_response_purchase_places)
+    assert 'Places available: 4' in html_response_purchase_places

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,4 +1,5 @@
 import pytest
+from html import unescape
 
 
 class TestIndex:
@@ -17,12 +18,13 @@ class TestIndex:
 
     def test_index_contains_expected_elements(self, client):
         response = client.get('/')
-        html = response.data.decode('utf-8')
+        html_response = unescape(response.data.decode('utf-8'))
 
-        assert '<h1>Welcome to the GUDLFT Registration Portal!</h1>' in html
-        assert '<form action="showSummary" method="post">' in html
-        assert '<input type="email" name="email" id=""/>' in html
-        assert '<button type="submit">Enter</button>' in html
+        assert ('<h1>Welcome to the GUDLFT Registration Portal!</h1>' in
+                html_response)
+        assert '<form action="showSummary" method="post">' in html_response
+        assert '<input type="email" name="email" id=""/>' in html_response
+        assert '<button type="submit">Enter</button>' in html_response
 
 
 class TestShowSummary:
@@ -52,13 +54,210 @@ class TestShowSummary:
     def test_login_email(self, client, mock_clubs, mock_competitions,
                          label, data, expected_code):
         response = client.post(path='/showSummary', data=data)
-        html = response.data.decode('utf-8')
+        html_response = unescape(response.data.decode('utf-8'))
 
         assert response.status_code == expected_code
         if expected_code != 200:
-            assert 'The provided email is not valid.' in html
+            assert 'The provided email is not valid.' in html_response
         else:
-            assert 'Welcome, {email}'.format(**data) in html
+            assert 'Welcome, {email}'.format(**data) in html_response
+
+
+class TestBook:
+    @pytest.mark.parametrize(
+        'method, expected_code',
+        [
+            ('GET', 302),
+            ('POST', 405),
+            ('PUT', 405),
+            ('DELETE', 405),
+            ('PATCH', 405),
+        ]
+    )
+    def test_book_route_methods(self, client, method, expected_code):
+        response = client.open(path=f"/book/competition/club", method=method)
+        assert response.status_code == expected_code
+
+    @pytest.mark.parametrize(
+        'label, data, expected_code, expected_page',
+        [
+            ('#EMPTY', {}, 308, 'index.html'),
+
+            ('#NO_COMPETITION', {'club': 'Club 001'},
+             308, 'index.html'),
+
+            ('#NO_CLUB', {'competition': 'Competition 001'},
+             302, 'index.html'),
+
+            ('#UNKNOWN_COMPETITION',
+             {'club': 'Club 001', 'competition': 'Unknown'},
+             404, 'welcome.html'),
+
+            ('#UNKNOWN_CLUB',
+             {'club': 'Unknown', 'competition': 'Competition 001'},
+             302, 'index.html'),
+
+            ('#GOOD_REQUEST',
+             {'club': 'Club 001', 'competition': 'Competition 001'},
+             200, 'booking.html')
+        ]
+    )
+    def test_book_return_expected_content(
+            self, client, mock_clubs, mock_competitions,
+            label, data, expected_code, expected_page):
+        club = data.get('club', '')
+        competition = data.get('competition', '')
+        response = client.get(f"/book/{competition}/{club}")
+        assert response.status_code == expected_code
+
+        if expected_code in (302, 308):
+            response = client.get(f"/book/{competition}/{club}",
+                                  follow_redirects=True)
+
+        html_response = unescape(response.data.decode("utf-8"))
+
+        if expected_page == 'index.html':
+            # verify page 'title'
+            assert 'GUDLFT Registration' in html_response
+            assert "Lost connection, please login" in html_response
+        elif expected_page == 'welcome.html':
+            # verify page 'title'
+            assert 'Summary | GUDLFT Registration' in html_response
+            assert "Something went wrong-please try again" in html_response
+        elif expected_page == 'booking.html':
+            # verify page 'title'
+            assert f'Booking for {competition} || GUDLFT' in html_response
+
+
+class TestPurchasePlaces:
+    @pytest.mark.parametrize(
+        'method, expected_code',
+        [
+            ('GET', 405),
+            ('POST', 302),
+            ('PUT', 405),
+            ('DELETE', 405),
+            ('PATCH', 405),
+        ]
+    )
+    def test_purchase_places_route_methods(self, client, method,
+                                           expected_code):
+        response = client.open(path=f"/purchasePlaces",
+                               method=method)
+        assert response.status_code == expected_code
+
+    @pytest.mark.parametrize(
+        "label, data, expected_code, expected_page",
+        [
+            ('#EMPTY', {}, 302, 'index.html'),
+
+            ('#NO_COMPETITION', {'club': 'Club 001'},
+             404, 'welcome.html'),
+
+            ('#NO_CLUB', {'competition': 'Competition 001'},
+             302, 'index.html'),
+
+            ('#UNKNOWN_COMPETITION',
+             {'club': 'Club 001', 'competition': 'Unknown'},
+             404, 'welcome.html'),
+
+            ('#UNKNOWN_CLUB',
+             {'club': 'Unknown', 'competition': 'Competition 001'},
+             302, 'index.html'),
+
+            ('#GOOD_REQUEST',
+             {'club': 'Club 001', 'competition': 'Competition 001',
+              'places': 1},
+             200, 'welcome.html')
+        ]
+    )
+    def test_purchase_places_return_expected_content(
+            self, client, mock_clubs, mock_competitions,
+            label, data, expected_code, expected_page):
+        # add assert for flashed message to anticipate for can't book past comp
+        response = client.post("/purchasePlaces", data=data)
+        assert response.status_code == expected_code
+
+        if expected_code == 302:
+            response = client.get(f"/book", data=data, follow_redirects=True)
+
+        html_response = unescape(response.data.decode("utf-8"))
+
+        if expected_page == 'index.html':
+            # verify page 'title'
+            assert 'GUDLFT Registration' in html_response
+            assert "Lost connection, please login" in html_response
+        elif expected_page == 'welcome.html' and expected_code == 404:
+            # verify page 'title'
+            assert 'Summary | GUDLFT Registration' in html_response
+            assert "Something went wrong-please try again" in html_response
+        elif expected_page == 'welcome.html' and expected_code == 200:
+            # verify page 'title'
+            assert 'Summary | GUDLFT Registration' in html_response
+            assert "Great-booking complete!" in html_response
+
+    @pytest.mark.parametrize(
+        'label, data, expected_page, expected_code, expected_flash',
+        [
+            ('#BUY_OK',
+             {'club': 'Club 001', 'competition': 'Competition 001',
+              'places': 5},
+             'welcome.html',
+             200,
+             'Great-booking complete!'),
+
+            ('#BUY_0',
+             {'club': 'Club 001', 'competition': 'Competition 001',
+              'places': 0},
+             'booking.html',
+             403,
+             'You must enter a valid number of places'),
+
+            ('#BUY_WRONG_TYPE',
+             {'club': 'Club 001', 'competition': 'Competition 001',
+              'places': "not_a_number"},
+             'booking.html',
+             403,
+             'You must enter a valid number of places'),
+
+            ('#BUY_NEG',
+             {'club': 'Club 001', 'competition': 'Competition 001',
+              'places': -5},
+             'booking.html',
+             403,
+             'You must enter a valid number of places'),
+
+            ('#BUY_MORE_THAN_CLUB_POINTS',
+             {'club': 'Club 002', 'competition': 'Competition 001',
+              'places': 8},
+             'booking.html',
+             403,
+             "You don't have enough points to proceed with your request. "
+             "Requested : 8, still allowed : 4"),
+
+            ('#BUY_MORE_THAN_COMP_PLACES',
+             {'club': 'Club 001', 'competition': 'Competition 002',
+              'places': 5},
+             'booking.html',
+             403,
+             'Not enough available places for this competition. '
+             'Requested : 5, still available : 4'),
+        ]
+
+    )
+    def test_purchase_places_good_request(
+            self, client, mock_clubs, mock_competitions,
+            label, data, expected_page, expected_code, expected_flash):
+        response = client.post("/purchasePlaces", data=data)
+        assert response.status_code == expected_code
+
+        html_response = unescape(response.data.decode("utf-8"))
+
+        assert expected_flash in html_response
+
+        if expected_code == 403:
+            assert 'Booking for {competition} || GUDLFT'.format(
+                **data) in html_response
 
 
 class TestLogout:


### PR DESCRIPTION
Side fixes:
- Data normalisation: when loading data from json, transform points and numberOfPlaces into type int.
- Route safety: added a redirect to index if book isn't reached with the right parameters
- Route safety: added a redirect to index or welcome if purchasePlaces isn't reached with the right parameters.

Flash a message for the book endpoint if the club purchase check one of with the following conditions:
- Club try to buy more than its points
- Club try to buy more than the competition places
- Club try to buy 0 or less places
- Club try to send a wrong type of places to the server (ex : {'places': 'not_an_int'})
