### PR TITLE
Bug/clubs shouldn't be able to book more than 12 places per competition

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ def client():
         yield client
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def mock_clubs(mocker):
     clubs = [
         {"name": "Club 001", "email": "001_club@gudlift.com", "points": 13},
@@ -22,7 +22,7 @@ def mock_clubs(mocker):
     return clubs
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def mock_competitions(mocker):
     competitions = [
         {"name": "Competition 001", "date": "2020-03-27 10:00:00",
@@ -32,3 +32,10 @@ def mock_competitions(mocker):
     ]
     mocker.patch.object(server, 'competitions', competitions)
     return competitions
+
+
+@pytest.fixture(autouse=True)
+def mock_past_transaction(mocker):
+    past_transaction = {}
+    mocker.patch.object(server, 'PAST_TRANSACTION', past_transaction)
+    return past_transaction

--- a/tests/integration/test_purchase_places.py
+++ b/tests/integration/test_purchase_places.py
@@ -98,3 +98,83 @@ def test_purchase_places_more_than_competition_places(
             'Requested : 5, still available : 4')
             in html_response_purchase_places)
     assert 'Places available: 4' in html_response_purchase_places
+
+
+def test_purchase_7_places_twice_to_try_to_bypass_maximum(
+        client, mock_clubs, mock_competitions, mock_past_transaction):
+
+    assert mock_competitions[0]['numberOfPlaces'] == 25
+    assert mock_past_transaction == {}
+
+    book_url = "/book/Competition 001/Club 003"
+    response_book = client.get(book_url)
+    html_response_book = response_book.data.decode("utf-8")
+
+    assert response_book.status_code == 200
+    assert (f"Booking for {mock_competitions[0]['name']} || GUDLFT"
+            in html_response_book)
+
+    request_args = {'club': 'Club 003', 'competition': 'Competition 001',
+                    'places': '7'}
+    response_purchase_places = client.post('/purchasePlaces',
+                                           data=request_args)
+    html_response_purchase_places = (
+        response_purchase_places.data.decode("utf-8"))
+
+    assert response_purchase_places.status_code == 200
+    assert mock_competitions[0]['numberOfPlaces'] == 18
+    assert 'Great-booking complete!' in html_response_purchase_places
+    assert 'Number of Places: 18' in html_response_purchase_places
+    assert mock_past_transaction[('Competition 001', 'Club 003')] == 7
+
+    second_request_args = {'club': 'Club 003', 'competition': 'Competition 001',
+                    'places': '7'}
+    second_response_purchase_places = client.post('/purchasePlaces',
+                                           data=second_request_args)
+    second_html_response_purchase_places = (
+        second_response_purchase_places.data.decode("utf-8"))
+
+    assert second_response_purchase_places.status_code == 403
+    assert (f"Booking for {mock_competitions[0]['name']} || GUDLFT"
+            in second_html_response_purchase_places)
+    assert ('Your request exceed the maximum allowed. Requested : 7, still '
+            'allowed 5') in second_html_response_purchase_places
+
+
+def test_purchase_7_places_then_5_to_reach_maximum(
+        client, mock_clubs, mock_competitions, mock_past_transaction):
+    assert mock_competitions[0]['numberOfPlaces'] == 25
+    assert mock_past_transaction == {}
+
+    book_url = "/book/Competition 001/Club 003"
+    response_book = client.get(book_url)
+    html_response_book = response_book.data.decode("utf-8")
+
+    assert response_book.status_code == 200
+    assert (f"Booking for {mock_competitions[0]['name']} || GUDLFT"
+            in html_response_book)
+
+    request_args = {'club': 'Club 003', 'competition': 'Competition 001',
+                    'places': '7'}
+    response_purchase_places = client.post('/purchasePlaces',
+                                           data=request_args)
+    html_response_purchase_places = (
+        response_purchase_places.data.decode("utf-8"))
+
+    assert response_purchase_places.status_code == 200
+    assert mock_competitions[0]['numberOfPlaces'] == 18
+    assert 'Great-booking complete!' in html_response_purchase_places
+    assert 'Number of Places: 18' in html_response_purchase_places
+    assert mock_past_transaction[('Competition 001', 'Club 003')] == 7
+
+    second_request_args = {'club': 'Club 003',
+                           'competition': 'Competition 001',
+                           'places': '5'}
+    second_response_purchase_places = client.post('/purchasePlaces',
+                                                  data=second_request_args)
+    second_html_response_purchase_places = (
+        second_response_purchase_places.data.decode("utf-8"))
+
+    assert second_response_purchase_places.status_code == 200
+    assert 'Great-booking complete!' in second_html_response_purchase_places
+    assert mock_past_transaction[('Competition 001', 'Club 003')] == 12


### PR DESCRIPTION
Side fixes:
+ fixture in configtest now reset between tests.

Prevent club from buying more than 12 places per competition.
+ Implementation of a hardcap in a global for server.py,
+ Club cannot buy more than 12 places at once
+ Club cannot buy more than 12 places total for a competition as multiple purchases.
+ A cache(dict) is registering purchases using a tuple of competition name and club name as key and purchased places as value.