### PR TITLE
Bug/booking places in past competitions

### DIFF
--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -16,9 +16,9 @@
        </ul>
     {% endif%}
     Points available: {{club['points']}}
-    <h3>Competitions:</h3>
+    <h3>Future Competitions:</h3>
     <ul>
-        {% for comp in competitions%}
+        {% for comp in future_competitions%}
         <li>
             {{comp['name']}}<br />
             Date: {{comp['date']}}</br>
@@ -26,6 +26,17 @@
             {%if comp['numberOfPlaces']|int >0%}
             <a href="{{ url_for('book',competition=comp['name'],club=club['name']) }}">Book Places</a>
             {%endif%}
+        </li>
+        <hr />
+        {% endfor %}
+    </ul>
+    <h3>Past Competitions:</h3>
+    <ul>
+        {% for comp in past_competitions%}
+        <li>
+            {{comp['name']}}<br />
+            Date: {{comp['date']}}</br>
+            Number of Places: {{comp['numberOfPlaces']}}
         </li>
         <hr />
         {% endfor %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
 import pytest
 import server
+from datetime import datetime, timedelta
+
+future_d = (datetime.now() + timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')
+past_d = (datetime.now() - timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')
 
 
 @pytest.fixture
@@ -25,12 +29,22 @@ def mock_clubs(mocker):
 @pytest.fixture(autouse=True)
 def mock_competitions(mocker):
     competitions = [
-        {"name": "Competition 001", "date": "2020-03-27 10:00:00",
+        {"name": "Competition 001", "date": future_d,
          "numberOfPlaces": 25},
-        {"name": "Competition 002", "date": "2020-10-22 13:30:00",
-         "numberOfPlaces": 4}
+        {"name": "Competition 002", "date": future_d,
+         "numberOfPlaces": 4},
+        {"name": "Competition 003", "date": past_d,
+         "numberOfPlaces": 9},
+        {"name": "Competition 004", "date": past_d,
+         "numberOfPlaces": 3},
     ]
+    past_competitions_ids = [2, 3]
+    future_competitions_ids = [0, 1]
+
     mocker.patch.object(server, 'competitions', competitions)
+    mocker.patch.object(server, 'past_competitions_ids', past_competitions_ids)
+    mocker.patch.object(server, 'future_competitions_ids',
+                        future_competitions_ids)
     return competitions
 
 

--- a/tests/integration/test_purchase_places.py
+++ b/tests/integration/test_purchase_places.py
@@ -178,3 +178,28 @@ def test_purchase_7_places_then_5_to_reach_maximum(
     assert second_response_purchase_places.status_code == 200
     assert 'Great-booking complete!' in second_html_response_purchase_places
     assert mock_past_transaction[('Competition 001', 'Club 003')] == 12
+
+
+def test_try_to_purchase_past_competition(
+        client, mock_clubs, mock_competitions):
+    assert mock_competitions[3]['numberOfPlaces'] == 3
+
+    book_url = "/book/Competition 004/Club 001"
+    response_book = client.get(book_url)
+    html_response_book = response_book.data.decode("utf-8")
+
+    assert response_book.status_code == 200
+    assert (f"Booking for {mock_competitions[3]['name']} || GUDLFT"
+            in html_response_book)
+
+    request_args = {'club': 'Club 001', 'competition': 'Competition 004',
+                    'places': '1'}
+    response_purchase_places = client.post('/purchasePlaces',
+                                           data=request_args)
+    html_response_purchase_places = (
+        response_purchase_places.data.decode("utf-8"))
+
+    assert response_purchase_places.status_code == 302
+    assert mock_competitions[3]['numberOfPlaces'] == 3
+    assert 'This competition is already over.' in html_response_purchase_places
+    assert 'Number of Places: 3' in html_response_purchase_places

--- a/tests/integration/test_purchase_places.py
+++ b/tests/integration/test_purchase_places.py
@@ -127,10 +127,10 @@ def test_purchase_7_places_twice_to_try_to_bypass_maximum(
     assert 'Number of Places: 18' in html_response_purchase_places
     assert mock_past_transaction[('Competition 001', 'Club 003')] == 7
 
-    second_request_args = {'club': 'Club 003', 'competition': 'Competition 001',
-                    'places': '7'}
+    second_request_args = {'club': 'Club 003',
+                           'competition': 'Competition 001', 'places': '7'}
     second_response_purchase_places = client.post('/purchasePlaces',
-                                           data=second_request_args)
+                                                  data=second_request_args)
     second_html_response_purchase_places = (
         second_response_purchase_places.data.decode("utf-8"))
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -331,6 +331,36 @@ class TestPurchasePlaces:
             assert 'Booking for {competition} || GUDLFT'.format(
                 **data) in html_response
 
+    @pytest.mark.parametrize(
+        'label, data, expected_page, expected_code, expected_flash',
+        [
+            ('#PAST_DATE',
+             {'club': 'Club 001', 'competition': 'Competition 003',
+              'places': 5},
+             'welcome.html',
+             302,
+             "This competition is already over."),
+
+            ('#FUTURE_DATE',
+             {'club': 'Club 001', 'competition': 'Competition 001',
+              'places': 5},
+             'welcome.html',
+             200,
+             'Great-booking complete!'
+             )
+        ]
+    )
+    def test_purchase_places_competition_dates(
+            self, client, mock_clubs, mock_competitions,
+            label, data,
+            expected_page, expected_code, expected_flash):
+        response = client.post("/purchasePlaces", data=data)
+        assert response.status_code == expected_code
+
+        html_response = unescape(response.data.decode("utf-8"))
+        assert expected_flash in html_response
+        assert 'Summary | GUDLFT Registration' in html_response
+
 
 class TestLogout:
     @pytest.mark.parametrize(


### PR DESCRIPTION
Prevent club from buying places for past competitions.
+ Template welcome.html modification to accomodate for a separation between the treatment of future and past competitions.
+ Soft block : link to past competitions removed from welcome template.
+ Hard block : check if competitions is in the past before processing transaction.